### PR TITLE
Remove Typhoeus on_complete workaround

### DIFF
--- a/lib/market_bot/android/app.rb
+++ b/lib/market_bot/android/app.rb
@@ -166,9 +166,6 @@ module MarketBot
         request = Typhoeus::Request.new(market_url, @request_opts)
 
         request.on_complete do |response|
-          # HACK: Typhoeus <= 0.4.2 returns a response, 0.5.0pre returns the request.
-          response = response.response if response.is_a?(Typhoeus::Request)
-
           result = nil
 
           begin


### PR DESCRIPTION
Gemspec specifies >= 0.6. This means it's always save to assume that on_complete
yields a response and not a request.