### PR TITLE
Descriptive error for app not found

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    market_bot (0.12.2)
+    market_bot (0.13.0)
       nokogiri
       typhoeus (>= 0.6.0)
 

--- a/lib/market_bot.rb
+++ b/lib/market_bot.rb
@@ -4,6 +4,7 @@ require 'typhoeus'
 require 'nokogiri'
 
 require 'market_bot/version'
+require 'market_bot/exceptions'
 require 'market_bot/android/app'
 require 'market_bot/android/leaderboard/constants'
 require 'market_bot/android/leaderboard'

--- a/lib/market_bot/android/app.rb
+++ b/lib/market_bot/android/app.rb
@@ -153,7 +153,7 @@ module MarketBot
 
       def update
         resp = Typhoeus::Request.get(market_url, @request_opts)
-        result = App.parse(resp.body)
+        result = handle_response(resp)
         update_callback(result)
 
         self
@@ -172,7 +172,7 @@ module MarketBot
           result = nil
 
           begin
-            result = App.parse(response.body)
+            result = handle_response(response)
           rescue Exception => e
             @error = e
           end
@@ -186,6 +186,15 @@ module MarketBot
       end
 
     private
+
+      def handle_response(response)
+        if response.success?
+          App.parse(response.body)
+        else
+          raise MarketBot::ResponseError.new("Got unexpected response code: #{response.code}")
+        end
+      end
+
       def update_callback(result)
         unless @error
           MARKET_ATTRIBUTES.each do |a|

--- a/lib/market_bot/exceptions.rb
+++ b/lib/market_bot/exceptions.rb
@@ -1,0 +1,4 @@
+module MarketBot
+  # Exception raised when an unsuccessful response is indicated by Typhoeus
+  class ResponseError < StandardError; end
+end

--- a/spec/market_bot/android/app_spec.rb
+++ b/spec/market_bot/android/app_spec.rb
@@ -179,6 +179,27 @@ describe 'App' do
       check_getters(app)
     end
 
+    context "Quick API not found" do
+      let(:app) { App.new(test_id) }
+
+      before do
+        response = Typhoeus::Response.new(:code => 404)
+        Typhoeus.stub(app.market_url).and_return(response)
+      end
+
+      it "doesn't raise a generic NoMethodError" do
+        expect {
+          app.update
+        }.to_not raise_error(NoMethodError)
+      end
+
+      it "raises a ResponseError" do
+        expect {
+          app.update
+        }.to raise_error(MarketBot::ResponseError)
+      end
+    end
+
     context 'Batch API' do
       hydra = Typhoeus::Hydra.new
       app = App.new(test_id, :hydra => hydra)


### PR DESCRIPTION
Exception structure styled under the advice found here: https://stackoverflow.com/questions/5200842/where-to-define-custom-error-types-in-ruby-and-or-rails

Currently, a request for an invalid package raises a `NoMethodError` on nil. This is pretty hard to `catch` without potentially catching a bunch of other things.

This PR represents a small departure from the existing style in the spec-file. I'm happy to work to make it uniform with your standards if this is something you'd like for the gem.