### PR TITLE
Remove NoMethodError test

### DIFF
--- a/spec/market_bot/android/app_spec.rb
+++ b/spec/market_bot/android/app_spec.rb
@@ -187,12 +187,6 @@ describe 'App' do
         Typhoeus.stub(app.market_url).and_return(response)
       end
 
-      it "doesn't raise a generic NoMethodError" do
-        expect {
-          app.update
-        }.to_not raise_error(NoMethodError)
-      end
-
       it "raises a ResponseError" do
         expect {
           app.update


### PR DESCRIPTION
This test causes an error in rspec >= 3 due to a deprecation of the `not_to
raise_error` syntax. The caller is instead expected to either specify that no
error will be raised, or give a specific error that will be raised.

Since the second case is covered by another test, this one can be removed.