### PR TITLE
Fixed an issue where there's no price or rating

### DIFF
--- a/lib/market_bot/play/app.rb
+++ b/lib/market_bot/play/app.rb
@@ -42,9 +42,9 @@ module MarketBot
           end
         end
 
-        result[:content_rating] = doc.at_css("div.content[itemprop='contentRating']").text
+        result[:content_rating] = doc.at_css("div.content[itemprop='contentRating']").text if doc.at_css("div.content[itemprop='contentRating']")
 
-        result[:price] = doc.at_css('meta[itemprop="price"]')[:content]
+        result[:price] = doc.at_css('meta[itemprop="price"]')[:content] if doc.at_css('meta[itemprop="price"]')
 
         category_div = doc.at_css('.category')
         result[:category] = category_div.text.strip


### PR DESCRIPTION
There won't always be rating and price. When it happens, the parsing fails.

This PR just ignores those two if they don't exist.

Example package name to reproduce the crash: `com.flaregames.nskchuck`