### PR TITLE
Replace obsolete URI.escape with CGI.escape

### DIFF
--- a/lib/market_bot/play/developer.rb
+++ b/lib/market_bot/play/developer.rb
@@ -10,7 +10,7 @@ module MarketBot
         num = 100
 
         url = "https://play.google.com/store/apps/developer?"
-        url << "id=#{URI.escape(@collection)}&"
+        url << "id=#{CGI.escape(@collection)}&"
         url << "start=0&"
         url << "gl=#{@country}&"
         url << "num=#{num}&"


### PR DESCRIPTION
`URI.escape` [is obsolete](https://ruby-doc.org/stdlib-2.5.0/libdoc/uri/rdoc/URI/Escape.html#escape-method).
Also, some developers can't be fetched when using `URI.escape`
E.g.  with `URI.escape` => 404
```
irb(main):008:0> MarketBot::Play::Developer.new('Fox & Sheep').update
ETHON: Libcurl initialized
ETHON: performed EASY effective_url=https://play.google.com/store/apps/developer?id=Fox%20&%20Sheep&start=0&gl=us&num=100&hl=en response_code=404 return_code=ok 
```
With `CGI.escape` the problem is fixed:
```
MarketBot::Play::Developer.new('Fox & Sheep').update
ETHON: Libcurl initialized
ETHON: performed EASY effective_url=https://play.google.com/store/apps/developer?id=Fox+%26+Sheep&start=0&gl=us&num=100&hl=en response_code=200 return_code=ok 
```
