### PR TITLE
Fix bugs in screenshot processing

### DIFF
--- a/lib/market_bot/play/app.rb
+++ b/lib/market_bot/play/app.rb
@@ -130,11 +130,11 @@ module MarketBot
           result[:cover_image_url] = MarketBot::Util.fix_content_url(node[:src])
         end
 
-        nodes                    = doc.search('img[alt="Screenshot Image"]')
+        nodes = doc.search('img[alt="Screenshot Image"]', 'img[alt="Screenshot"]')
         result[:screenshot_urls] = []
-        unless node.nil?
+        unless nodes.nil?
           result[:screenshot_urls] = nodes.map do |n|
-            result[:screenshot_urls] << MarketBot::Util.fix_content_url(n[:src])
+            MarketBot::Util.fix_content_url(n[:src])
           end
         end
 


### PR DESCRIPTION
`nodes` (plural) holds the result of the screenshot search. However, the nil
check was erroneously performed on the `node` (singular) variable.

`result[:screenshot_urls]` contained duplicate data due to a
similtaneous assignment and modification of the array.

Alt text for screenshots can be either 'Screenshot' or 'Screenshot
Image'.